### PR TITLE
Add instructor note about lack of issues on forks in PR basics, add side note to slides

### DIFF
--- a/instructor-notes/08_pull-requests-basics.md
+++ b/instructor-notes/08_pull-requests-basics.md
@@ -50,6 +50,7 @@ In the most recent session, participants will have created two branches:
 * In the pull request title, ask participants to describe the changes in `add-renv` branch at a high-level.
 * In the pull request description, ask participants to include a brief summary of the changes made in the `add-renv` branch.
     * Make sure to reference the issue number for the `renv` addition.
+    * Note that, by default, participants' forks will not have issues enabled, so their repository will look different from the one in the demo.
 * Point out that merging is blocked in the repository the instructor is using because the `main` branch is protected.
 * Navigate to the repository settings and show how branch protection rules are set up.
   * Stress that protecting the `main` branch when working in their own repositories is not practical, and that participants should not follow along in setting this up in their fork.


### PR DESCRIPTION
Specifically, the planning and tracking work slides (slide 19), which you can see here: https://docs.google.com/presentation/d/1I16QMWql5dXJqdzWeHiovvJ3s5JXfWvxZDaR9uZld2Q/edit?slide=id.g347d8bf30c1_0_2#slide=id.g347d8bf30c1_0_2

I think this is the only logical place to put it in the slides, but it makes sense that we call this out during the first pull request demo. So, I've put it in the instructor notes here.

Therefore, this closes #61, in my opinion.